### PR TITLE
Work weeks are now scoped to current company

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,9 @@ class User < ActiveRecord::Base
     def for_project(project)
       self.select { |ww| ww.project_id == project.id }
     end
+    def for_projects(project_ids)
+      self.select { |ww| project_ids.include? ww.project_id }
+    end
   end
 
   after_update do |user|

--- a/app/views/staffplans/index.html.haml
+++ b/app/views/staffplans/index.html.haml
@@ -34,11 +34,10 @@
     - @users.each do |user|
       %li
         = render partial: 'shared/user-info', locals: {user: user, url: staffplan_url(user)}
-        
         %ul.week-hour-counter
           - @date_range.each do |date|
             - css_class = ((date <= Date.today) ?  'passed' : '')
-            - work_weeks_for_date = user.work_weeks.select { |ww| ww.cweek == date.cweek && ww.year == date.year }
+            - work_weeks_for_date = user.work_weeks.for_projects(user.current_company.projects.map(&:id)).select { |ww| ww.cweek == date.cweek && ww.year == date.year }
             - actual_or_estimated_hours = (date.past? || date.today?) ? :actual_hours : :estimated_hours
             - total = work_weeks_for_date.map { |ww| ww.send(actual_or_estimated_hours) || 0 }.inject(:+) || 0
             - if total == 0 && actual_or_estimated_hours == :actual_hours


### PR DESCRIPTION
i.e. We only show estimates and actuals for the work_weeks associated
with projects of the current_user's current_company.
Tried to keep the changes as minimal as possible to facilitate tweaking
and revert if needed.
