### PR TITLE
Fixes errors and deprecation warnings in specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development, :test do
   gem 'mocha'
   gem 'rspec-rails',      '2.8.1'
   gem 'webrat'
-  gem 'simplecov', :require => false
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,10 +194,6 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    simplecov (0.6.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.5.3)
-    simplecov-html (0.5.3)
     slop (2.4.4)
     sprockets (2.1.2)
       hike (~> 1.2)
@@ -254,7 +250,6 @@ DEPENDENCIES
   rails-behaviors
   rspec-rails (= 2.8.1)
   sass-rails (~> 3.2.3)
-  simplecov
   thin
   uglifier (>= 1.0.3)
   webrat

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,9 +1,11 @@
-ActionMailer::Base.smtp_settings = {
-  :address        => 'smtp.sendgrid.net',
-  :port           => '587',
-  :authentication => :plain,
-  :user_name      => ENV['SENDGRID_USERNAME'],
-  :password       => ENV['SENDGRID_PASSWORD'],
-  :domain         => 'heroku.com'
-}
-ActionMailer::Base.delivery_method = :smtp
+if Rails.env == "production"
+  ActionMailer::Base.smtp_settings = {
+    :address        => 'smtp.sendgrid.net',
+    :port           => '587',
+    :authentication => :plain,
+    :user_name      => ENV['SENDGRID_USERNAME'],
+    :password       => ENV['SENDGRID_PASSWORD'],
+    :domain         => 'heroku.com'
+  }
+  ActionMailer::Base.delivery_method = :smtp
+end

--- a/lib/staff_plan/work_weeks_controllers.rb
+++ b/lib/staff_plan/work_weeks_controllers.rb
@@ -7,7 +7,7 @@ module StaffPlan::WorkWeeksControllers
     before_filter :find_work_week, :only => :update
   end
   
-  module InstanceMethods
+  #module InstanceMethods
     def create
       @work_week = WorkWeek.new(whitelist_attributes)
       @work_week.project_id = @project.id
@@ -74,5 +74,5 @@ module StaffPlan::WorkWeeksControllers
       base
     end
     
-  end
+  #end
 end

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -9,7 +9,7 @@ describe ClientsController do
   
   describe "GET index" do
     it "assigns all clients as @clients" do
-      client = Factory(:client)
+      client = FactoryGirl.create(:client)
       @company.clients << client
       get :index
       assigns(:clients).should eq([client])
@@ -18,7 +18,7 @@ describe ClientsController do
 
   describe "GET show" do
     it "assigns the requested client as @client" do
-      client = Factory(:client)
+      client = FactoryGirl.create(:client)
       @company.clients << client
       get :show, :id => client.id
       assigns(:client).should eq(client)
@@ -34,7 +34,7 @@ describe ClientsController do
 
   describe "GET edit" do
     it "assigns the requested client as @client" do
-      client = Factory(:client)
+      client = FactoryGirl.create(:client)
       @company.clients << client
       get :edit, :id => client.id
       assigns(:client).should eq(client)
@@ -45,24 +45,24 @@ describe ClientsController do
     context "with valid params" do
       it "creates a new Client" do
         expect {
-          post :create, :client => Factory.attributes_for(:client)
+          post :create, :client => FactoryGirl.attributes_for(:client)
         }.to change(Client, :count).by(1)
       end
 
       it "assigns a newly created client as @client" do
-        post :create, :client => Factory.attributes_for(:client)
+        post :create, :client => FactoryGirl.attributes_for(:client)
         assigns(:client).should be_a(Client)
         assigns(:client).should be_persisted
       end
       
       it "should add the new client to the current_user.current_company" do
-        client = Factory.build(:client)
+        client = FactoryGirl.build(:client)
         post :create, :client => client.attributes
         @current_user.current_company.clients.find_by_name(client.name).should_not be_nil
       end
 
       it "redirects to the created client" do
-        post :create, :client => Factory.attributes_for(:client)
+        post :create, :client => FactoryGirl.attributes_for(:client)
         # Due to the default_scope being ORDER BY name DESC we need to bypass the scope here
         response.should redirect_to(Client.send(:with_exclusive_scope){Client.last})
       end
@@ -88,7 +88,7 @@ describe ClientsController do
   describe "PUT update" do
     context "with valid params" do
       it "updates the requested client" do
-        client = Factory(:client)
+        client = FactoryGirl.create(:client)
         @company.clients << client
         # Assuming there are no other clients in the database, this
         # specifies that the Client created on the previous line
@@ -100,23 +100,23 @@ describe ClientsController do
       end
 
       it "assigns the requested client as @client" do
-        client = Factory(:client)
+        client = FactoryGirl.create(:client)
         @company.clients << client
-        put :update, :id => client.id, :client => Factory.attributes_for(:client)
+        put :update, :id => client.id, :client => FactoryGirl.attributes_for(:client)
         assigns(:client).should eq(client)
       end
 
       it "redirects to the client" do
-        client = Factory(:client)
+        client = FactoryGirl.create(:client)
         @company.clients << client
-        put :update, :id => client.id, :client => Factory.attributes_for(:client)
+        put :update, :id => client.id, :client => FactoryGirl.attributes_for(:client)
         response.should redirect_to(client)
       end
     end
 
     context "with invalid params" do
       it "assigns the client as @client" do
-        client = Factory(:client)
+        client = FactoryGirl.create(:client)
         @company.clients << client
         # Trigger the behavior that occurs when invalid params are submitted
         Client.any_instance.expects(:save).returns(false)
@@ -125,7 +125,7 @@ describe ClientsController do
       end
 
       it "re-renders the 'edit' template" do
-        client = Factory(:client)
+        client = FactoryGirl.create(:client)
         @company.clients << client
         # Trigger the behavior that occurs when invalid params are submitted
         Client.any_instance.expects(:save).returns(false)
@@ -137,7 +137,7 @@ describe ClientsController do
 
   describe "DELETE destroy" do
     it "destroys the requested client" do
-      client = Factory(:client)
+      client = FactoryGirl.create(:client)
       @company.clients << client
       expect {
         delete :destroy, :id => client.id
@@ -145,7 +145,7 @@ describe ClientsController do
     end
 
     it "redirects to the clients list" do
-      client = Factory(:client)
+      client = FactoryGirl.create(:client)
       delete :destroy, :id => client.id
       response.should redirect_to(clients_url)
     end

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -17,18 +17,18 @@ describe CompaniesController do
   describe "POST create" do
     it "creates a new Company with valid params" do
       expect {
-        post :create, company: {name: Faker::Company.name}, user: Factory.attributes_for(:user) 
+        post :create, company: {name: Faker::Company.name}, user: FactoryGirl.attributes_for(:user) 
       }.to change(Company, :count).by(1)
     end
       
     it "should redirect to the user's staff plan page on successful company/user creation" do
-      post :create, company: {name: Faker::Company.name}, user: Factory.attributes_for(:user) 
+      post :create, company: {name: Faker::Company.name}, user: FactoryGirl.attributes_for(:user) 
       response.should redirect_to(root_url)
     end
       
     it "should create a new user and set the company's id as his/her current_company_id on a successful POST" do
       expect {
-        post :create, company: {name: Faker::Company.name}, user: Factory.attributes_for(:user) 
+        post :create, company: {name: Faker::Company.name}, user: FactoryGirl.attributes_for(:user) 
       }.to change(User, :count).by(1)
       
       assigns[:user].current_company_id.should eq(assigns[:company].id)
@@ -36,7 +36,7 @@ describe CompaniesController do
 
     it "should redirect to companies/new if the company cannot be saved" do
       lambda {
-        post :create, company: {name: ''}, user: Factory.attributes_for(:user) 
+        post :create, company: {name: ''}, user: FactoryGirl.attributes_for(:user) 
       }.should_not change(Company, :count)
         
       assigns[:company].should be_new_record
@@ -47,7 +47,7 @@ describe CompaniesController do
     it "should not create a new company or user if the company save fails" do
       Company.any_instance.expects(:save).returns(false)
       
-      post :create, company: {name: Faker::Company.name}, user: Factory.attributes_for(:user)
+      post :create, company: {name: Faker::Company.name}, user: FactoryGirl.attributes_for(:user)
       
       assigns[:company].should be_new_record
       assigns[:user].should be_new_record
@@ -55,7 +55,7 @@ describe CompaniesController do
     end
     
     it "should not create a new company or user if the user association with the company fails" do
-      user_attributes = Factory.attributes_for(:user); user_attributes.delete(:password)
+      user_attributes = FactoryGirl.attributes_for(:user); user_attributes.delete(:password)
       post :create, company: {name: Faker::Company.name}, user: user_attributes
       
       assigns[:company].should be_new_record
@@ -64,7 +64,7 @@ describe CompaniesController do
     end
     
     it "should not set current_company_id on the user if the user has access to other companies" do
-      user = Factory(:user); company = Factory(:company); company.users << user; user.current_company = company
+      user = FactoryGirl.create(:user); company = FactoryGirl.create(:company); company.users << user; user.current_company = company
       
       lambda {
         post :create, company: {name: Faker::Company.name}, user: { email: user.email }

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PasswordResetsController do
 
   before(:each) do
-    @user = Factory(:user)
+    @user = FactoryGirl.create(:user)
   end
 
   describe "PasswordResetsController#new (GET)" do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -6,15 +6,15 @@ describe ProjectsController do
     @current_user, @company = login_user
   end
 
-  def valid_attributes(client = Factory(:client))
-    attributes = Factory.attributes_for(:project)
+  def valid_attributes(client = FactoryGirl.create(:client))
+    attributes = FactoryGirl.attributes_for(:project)
     attributes.delete(:client)
     attributes.merge!(client_id: client.id)
   end
 
   describe "GET index" do
     it "assigns all projects as @projects but only returns projects associated to the current user's account" do
-      project = Factory(:project)
+      project = FactoryGirl.create(:project)
 
       @company.projects << project
 
@@ -30,7 +30,7 @@ describe ProjectsController do
 
   describe "GET show" do
     it "assigns the requested project as @project" do
-      project = Factory(:project)
+      project = FactoryGirl.create(:project)
       @company.projects << project
       get :show, :id => project.id
       assigns(:project).should eq(project)
@@ -46,7 +46,7 @@ describe ProjectsController do
 
   describe "GET edit" do
     it "assigns the requested project as @project" do
-      project = Factory(:project)
+      project = FactoryGirl.create(:project)
       @company.projects << project
       get :edit, :id => project.id
       assigns(:project).should eq(project)
@@ -91,14 +91,14 @@ describe ProjectsController do
       it "assigns a newly created but unsaved project as @project" do
         # Trigger the behavior that occurs when invalid params are submitted
         Project.any_instance.expects(:save).returns(false)
-        post :create, :project => {client_id: Factory(:client).id}
+        post :create, :project => {client_id: FactoryGirl.create(:client).id}
         assigns(:project).should be_a_new(Project)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         Project.any_instance.expects(:save).returns(false)
-        post :create, :project => {client_id: Factory(:client).id}
+        post :create, :project => {client_id: FactoryGirl.create(:client).id}
         response.should render_template("new")
       end
     end
@@ -107,7 +107,7 @@ describe ProjectsController do
   describe "PUT update" do
     describe "with valid params" do
       it "updates the requested project" do
-        project = Factory(:project)
+        project = FactoryGirl.create(:project)
         @company.projects << project
         # Assuming there are no other projects in the database, this
         # specifies that the Project created on the previous line
@@ -118,14 +118,14 @@ describe ProjectsController do
       end
 
       it "assigns the requested project as @project" do
-        project = Factory(:project)
+        project = FactoryGirl.create(:project)
         @company.projects << project
         put :update, :id => project.id, :project => valid_attributes
         assigns(:project).should eq(project)
       end
 
       it "redirects to the project" do
-        project = Factory(:project)
+        project = FactoryGirl.create(:project)
         @company.projects << project
         put :update, :id => project.id, :project => valid_attributes
         response.should redirect_to(project)
@@ -134,7 +134,7 @@ describe ProjectsController do
 
     describe "with invalid params" do
       it "assigns the project as @project" do
-        project = Factory(:project)
+        project = FactoryGirl.create(:project)
         @company.projects << project
         # Trigger the behavior that occurs when invalid params are submitted
         Project.any_instance.expects(:save).returns(false)
@@ -143,7 +143,7 @@ describe ProjectsController do
       end
 
       it "re-renders the 'edit' template" do
-        project = Factory(:project)
+        project = FactoryGirl.create(:project)
         @company.projects << project
         # Trigger the behavior that occurs when invalid params are submitted
         Project.any_instance.expects(:save).returns(false)
@@ -155,7 +155,7 @@ describe ProjectsController do
 
   describe "DELETE destroy" do
     it "destroys the requested project" do
-      project = Factory(:project)
+      project = FactoryGirl.create(:project)
       @company.projects << project
       expect {
         delete :destroy, :id => project.id
@@ -163,7 +163,7 @@ describe ProjectsController do
     end
 
     it "redirects to the projects list" do
-      project = Factory(:project)
+      project = FactoryGirl.create(:project)
       @company.projects << project
       delete :destroy, :id => project.id
       response.should redirect_to(projects_url)

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -109,7 +109,7 @@ describe RegistrationsController do
     describe "GET#confirm" do
       context "when the user is found" do
         it "should render the confirm template" do
-          @user = Factory.build(:user, password: nil, password_confirmation: nil, registration_token: token = 'anything')
+          @user = FactoryGirl.build(:user, password: nil, password_confirmation: nil, registration_token: token = 'anything')
           @user.save_unconfirmed_user
           get :confirm, token: token
           response.should render_template('confirm')
@@ -128,7 +128,7 @@ describe RegistrationsController do
     describe "POST#complete" do
       context "User is found with his token" do
         it "should reset the user's registration token and its timestamp to nil and redirect to his/her staffplan page" do
-          @user = Factory(:user, registration_token: token = "whatevs")
+          @user = FactoryGirl.create(:user, registration_token: token = "whatevs")
           @user.registration_token = SecureRandom.urlsafe_base64
           User.stubs(:with_registration_token).with(anything).returns(@user)
           post :complete, token: token, user: {first_name: @user.first_name, last_name: @user.last_name, email: @user.email, password: "foobar", password_confirmation: nil}
@@ -139,7 +139,7 @@ describe RegistrationsController do
       end
 
       it "should set the user as the current user by stuffing his id in session" do
-        @user = Factory(:user)
+        @user = FactoryGirl.create(:user)
         @user.registration_token = SecureRandom.urlsafe_base64
         User.stubs(:with_registration_token).with(anything).returns(@user)
         post :complete, token: "donkey"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,14 +12,14 @@ describe SessionsController do
 
   describe "POST#create" do
     it "should log the user in if the credentials are valid" do
-      user = Factory(:user)
+      user = FactoryGirl.create(:user)
       post :create, email: user.email, password: user.password
       response.should be_redirect
       response.should redirect_to(root_url)
     end
     
     it "should log the user in if the credentials are valid and redirect him/her to the resource he/she wanted to access initially" do
-      user = Factory(:user)
+      user = FactoryGirl.create(:user)
       request.cookies[:original_request] = Marshal.dump({controller: "staffplans", action: "index"}) 
       post :create, email: user.email, password: user.password
       response.should be_redirect
@@ -42,7 +42,7 @@ describe SessionsController do
 
   describe "GET#destroy" do
     it "should set session[:user_id] to nil" do
-      @current_user = Factory(:user)
+      @current_user = FactoryGirl.create(:user)
       login_user(user: @current_user)
       
       get :destroy

--- a/spec/controllers/staffplans_controller_spec.rb
+++ b/spec/controllers/staffplans_controller_spec.rb
@@ -5,9 +5,9 @@ describe StaffplansController do
     @current_user, @company = login_user
 
     3.times do |i|
-      c = Factory(:client)
+      c = FactoryGirl.create(:client)
       2.times do |j|
-        c.projects << Factory(:project)
+        c.projects << FactoryGirl.create(:project)
       end
       instance_variable_set("@client_#{i+1}", c)
     end
@@ -54,7 +54,7 @@ describe StaffplansController do
 
     it "should only show clients and projects for the current user's current company when I go to my staff plan page" do
 
-      @other_company = Factory(:company)
+      @other_company = FactoryGirl.create(:company)
       @other_company.clients << @client_2
       @other_company.clients << @client_3
 
@@ -138,7 +138,7 @@ describe StaffplansController do
       it "should only show workload estimates for users belonging to the current user's current company" do
         @company.users << user_with_clients_and_projects
         other_user = user_with_clients_and_projects
-        other_company = Factory(:company)
+        other_company = FactoryGirl.create(:company)
         other_company.users << other_user
         get :index
         assigns[:users].size.should eq(@company.users.size)

--- a/spec/controllers/users/projects/work_weeks_controller_spec.rb
+++ b/spec/controllers/users/projects/work_weeks_controller_spec.rb
@@ -4,7 +4,7 @@ describe Users::Projects::WorkWeeksController do
 
   before(:each) do
     @user, @company = login_user
-    @project = Factory(:project, :users => [@user], company: @company)
+    @project = FactoryGirl.create(:project, :users => [@user], company: @company)
   end
 
   def base_params
@@ -31,7 +31,7 @@ describe Users::Projects::WorkWeeksController do
           cweek: Date.today.cweek, 
           year: Date.today.year 
         }) 
-        ww = Factory(:work_week, parameters) 
+        ww = FactoryGirl.create(:work_week, parameters) 
         lambda {post :create, parameters.merge(format: "js")}.should_not change(WorkWeek, :count) 
 
         @body = JSON.parse(response.body)
@@ -57,7 +57,7 @@ describe Users::Projects::WorkWeeksController do
   describe '#update' do
 
     before(:each) do
-      @work_week = Factory(:work_week, user: @user, project: @project)
+      @work_week = FactoryGirl.create(:work_week, user: @user, project: @project)
     end
 
     context "format: 'js'" do

--- a/spec/controllers/users/projects_controller_spec.rb
+++ b/spec/controllers/users/projects_controller_spec.rb
@@ -54,7 +54,7 @@ describe Users::ProjectsController do
     
     context "with new OR existing clients" do
       it "should find the client by name without regard to case of the name" do
-        client = Factory(:client, company: @company)
+        client = FactoryGirl.create(:client, company: @company)
         
         lambda {
           post :create, :user_id => @user.id, :client_name => client.name.upcase, :name => @project_name
@@ -88,7 +88,7 @@ describe Users::ProjectsController do
       end
       
       it "should find existing projects for the client without regard to case of the name" do
-        client = Factory(:client, company: @company)
+        client = FactoryGirl.create(:client, company: @company)
         
         lambda {
           post :create, :user_id => @user.id, :client_name => client.name, :name => @project_name
@@ -112,7 +112,7 @@ describe Users::ProjectsController do
     end
     
     it "should render OK JSON if the project updates" do
-      put :update, :user_id => @user.id, :id => Factory(:project, company: @company, :users => [@user]).id
+      put :update, :user_id => @user.id, :id => FactoryGirl.create(:project, company: @company, :users => [@user]).id
       response.should be_success
       response.body.match("\"status\":\"ok\"").should_not be_nil
       response.body.match("\"clients\":").should_not be_nil
@@ -121,7 +121,7 @@ describe Users::ProjectsController do
     
     it "should render FAIL JSON if the project doesn't update" do
       Project.any_instance.expects(:update_attributes).with(anything).returns(false)
-      put :update, :user_id => @user.id, :id => Factory(:project, company: @company, :users => [@user]).id
+      put :update, :user_id => @user.id, :id => FactoryGirl.create(:project, company: @company, :users => [@user]).id
       response.should be_success
       response.body.match("\"status\":\"fail\"").should_not be_nil
       response.body.match("\"errors\":").should_not be_nil
@@ -138,7 +138,7 @@ describe Users::ProjectsController do
     end
     
     it "should remove the project from the target user's projects" do
-      project = Factory(:project, company: @company, :users => [@user])
+      project = FactoryGirl.create(:project, company: @company, :users => [@user])
       @user.reload.projects.map(&:name).should include(project.name)
       delete :destroy, :user_id => @user.id, :id => project.id
       @user.reload.projects.map(&:name).should_not include(project.name)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -15,7 +15,7 @@ describe UsersController do
 
   describe "GET show" do
     it "assigns the requested user as @user" do
-      user = Factory(:user)
+      user = FactoryGirl.create(:user)
       @company.users << user
       get :show, :id => user.id
       assigns(:user).should eq(user)
@@ -31,7 +31,7 @@ describe UsersController do
 
   describe "GET edit" do
     it "assigns the requested user as @user" do
-      user = Factory(:user)
+      user = FactoryGirl.create(:user)
       @company.users << user
       get :edit, :id => user.id
       assigns(:user).should eq(user)
@@ -92,7 +92,7 @@ describe UsersController do
   describe "PUT update" do
     describe "with valid params" do
       it "updates the requested user" do
-        user = Factory(:user)
+        user = FactoryGirl.create(:user)
         @company.users << user
         # Assuming there are no other users in the database, this
         # specifies that the User created on the previous line
@@ -103,22 +103,22 @@ describe UsersController do
       end
 
       it "assigns the requested user as @user" do
-        user = Factory(:user)
+        user = FactoryGirl.create(:user)
         @company.users << user
-        put :update, :id => user.id, :user => Factory.attributes_for(:user)
+        put :update, :id => user.id, :user => FactoryGirl.attributes_for(:user)
         assigns(:user).should eq(user)
       end
 
       it "redirects to the user" do
-        user = Factory(:user)
+        user = FactoryGirl.create(:user)
         @company.users << user
-        put :update, :id => user.id, :user => Factory.attributes_for(:user)
+        put :update, :id => user.id, :user => FactoryGirl.attributes_for(:user)
         response.should redirect_to(user)
       end
 
       it "should let people change their current_company" do
         request.env["HTTP_REFERER"] = staffplan_url(@current_user)
-        other_company = Factory(:company)
+        other_company = FactoryGirl.create(:company)
         other_company.users << @current_user
         put :update, :id => @current_user.id, :user => {current_company_id: other_company.id} 
         assigns[:user].current_company.should eq(other_company)
@@ -127,7 +127,7 @@ describe UsersController do
 
       it "should just redirect to back and do nothing if the specified company_id is not one the user belongs to" do
         request.env["HTTP_REFERER"] = staffplan_url(@current_user)
-        other_company = Factory(:company)
+        other_company = FactoryGirl.create(:company)
         lambda {
           put :update, :id => @current_user.id, :user => {current_company_id: other_company.id} 
         }.should_not change(@current_user, :current_company_id)
@@ -137,7 +137,7 @@ describe UsersController do
 
     describe "with invalid params" do
       it "assigns the user as @user" do
-        user = Factory(:user)
+        user = FactoryGirl.create(:user)
         @company.users << user
         # Trigger the behavior that occurs when invalid params are submitted
         User.any_instance.expects(:save).returns(false)
@@ -146,7 +146,7 @@ describe UsersController do
       end
 
       it "re-renders the 'edit' template" do
-        user = Factory(:user)
+        user = FactoryGirl.create(:user)
         @company.users << user
         # Trigger the behavior that occurs when invalid params are submitted
         User.any_instance.expects(:save).returns(false)
@@ -158,7 +158,7 @@ describe UsersController do
 
   describe "DELETE destroy" do
     it "destroys the requested user" do
-      user = Factory(:user)
+      user = FactoryGirl.create(:user)
       @company.users << user
       expect {
         delete :destroy, :id => user.id
@@ -166,7 +166,7 @@ describe UsersController do
     end
 
     it "redirects to the users list" do
-      user = Factory(:user)
+      user = FactoryGirl.create(:user)
       @company.users << user
       delete :destroy, :id => user.id
       response.should redirect_to(users_url)

--- a/spec/factories/work_weeks.rb
+++ b/spec/factories/work_weeks.rb
@@ -2,7 +2,7 @@
 
 FactoryGirl.define do
   factory :work_week do
-    user      { Factory(:user) }
-    project   { Factory(:project) }
+    user      { FactoryGirl.create(:user) }
+    project   { FactoryGirl.create(:project) }
   end
 end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -15,9 +15,9 @@ describe Client do
   describe "after_update callback" do
     it "should update the updated_at timestamp for a user that modifies a company" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         time = @source.updated_at
-        @target = Factory(:client)
+        @target = FactoryGirl.create(:client)
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(name: Faker::Company.name)
         @source.reload.updated_at.should > time
@@ -25,10 +25,10 @@ describe Client do
     end
     it "should NOT update the updated_at timestamp for user A if user B modifies something about a company" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         source_time = @source.updated_at
-        @target = Factory(:client)
-        @bystander = Factory(:user)
+        @target = FactoryGirl.create(:client)
+        @bystander = FactoryGirl.create(:user)
         bystander_time = @bystander.updated_at
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(name: Faker::Company.name)

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -4,9 +4,9 @@ describe Company do
   describe "after_update callback" do
     it "should update the updated_at timestamp for a user that modifies a company" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         time = @source.updated_at
-        @target = Factory(:company)
+        @target = FactoryGirl.create(:company)
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(name: Faker::Company.name)
         @source.reload.updated_at.should > time
@@ -14,10 +14,10 @@ describe Company do
     end
     it "should NOT update the updated_at timestamp for user A if user B modifies something about a company" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         source_time = @source.updated_at
-        @target = Factory(:company)
-        @bystander = Factory(:user)
+        @target = FactoryGirl.create(:company)
+        @bystander = FactoryGirl.create(:user)
         bystander_time = @bystander.updated_at
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(name: Faker::Company.name)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,16 +8,16 @@ describe Project do
     
     it "should be valid? with valid attributes" do
       project = Project.new(name: Faker::Company.bs)
-      project.client = Factory(:client)
+      project.client = FactoryGirl.create(:client)
       project.valid?.should be_true
     end
   end
   describe "after_update callback" do
     it "should update the updated_at timestamp for a user that modifies a project" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         time = @source.updated_at
-        @target = Factory(:project)
+        @target = FactoryGirl.create(:project)
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(name: Faker::Company.name)
         @source.reload.updated_at.should > time
@@ -25,10 +25,10 @@ describe Project do
     end
     it "should NOT update the updated_at timestamp for user A if user B modifies something about a company" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         source_time = @source.updated_at
-        @target = Factory(:project)
-        @bystander = Factory(:user)
+        @target = FactoryGirl.create(:project)
+        @bystander = FactoryGirl.create(:user)
         bystander_time = @bystander.updated_at
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(name: Faker::Company.name)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ describe User do
   describe '#plan_for' do
     before(:each) do
       @user = User.new(email: Faker::Internet.email, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: "23kj23k2j")
-      @company = Factory(:company)
+      @company = FactoryGirl.create(:company)
       @company.users << @user
       @user.current_company_id = @company.id
       @user.save
@@ -76,9 +76,9 @@ describe User do
   describe "after_update callback" do
     it "should update the updated_at timestamp for a user that modifies another user" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         time = @source.updated_at
-        @target = Factory(:user)
+        @target = FactoryGirl.create(:user)
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(first_name: Faker::Name.first_name)
         @source.reload.updated_at.should > time
@@ -86,10 +86,10 @@ describe User do
     end
     it "should NOT update the updated_at timestamp for user A if user B modifies something about user C" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         source_time = @source.updated_at
-        @target = Factory(:user)
-        @bystander = Factory(:user)
+        @target = FactoryGirl.create(:user)
+        @bystander = FactoryGirl.create(:user)
         bystander_time = @bystander.updated_at
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(first_name: Faker::Name.first_name)
@@ -101,14 +101,14 @@ describe User do
   describe '#save_unconfirmed_user' do
     it "should save the user if all required fields (except password) are present" do
       lambda {
-        user = Factory.build(:user, password: nil, password_confirmation: nil)
+        user = FactoryGirl.build(:user, password: nil, password_confirmation: nil)
         user.save_unconfirmed_user.should be_true
       }.should change(User, :count).by(1)
     end
     
     it "should not save if first/last name or email are missing" do
       lambda {
-        user = Factory.build(:user, password: nil, password_confirmation: nil, email: nil)
+        user = FactoryGirl.build(:user, password: nil, password_confirmation: nil, email: nil)
         user.save_unconfirmed_user.should be_false
       }.should_not change(User, :count)
     end

--- a/spec/models/work_week_spec.rb
+++ b/spec/models/work_week_spec.rb
@@ -8,8 +8,8 @@ describe WorkWeek do
     
     it "should be valid? with valid attributes" do
       work_week = WorkWeek.new
-      work_week.user = Factory(:user)
-      work_week.project = Factory(:project)
+      work_week.user = FactoryGirl.create(:user)
+      work_week.project = FactoryGirl.create(:project)
       work_week.valid?.should be_true
     end
     
@@ -38,9 +38,9 @@ describe WorkWeek do
   describe "after_update callback" do
     it "should update the updated_at timestamp for a user that modifies a work_week" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         time = @source.updated_at
-        @target = Factory(:work_week)
+        @target = FactoryGirl.create(:work_week)
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(cweek: Date.today.cweek)
         @source.reload.updated_at.should > time
@@ -48,10 +48,10 @@ describe WorkWeek do
     end
     it "should NOT update the updated_at timestamp for user A if user B modifies something about a work_week" do
       with_versioning do
-        @source = Factory(:user)
+        @source = FactoryGirl.create(:user)
         source_time = @source.updated_at
-        @target = Factory(:work_week)
-        @bystander = Factory(:user)
+        @target = FactoryGirl.create(:work_week)
+        @bystander = FactoryGirl.create(:user)
         bystander_time = @bystander.updated_at
         PaperTrail.whodunnit = @source.id.to_s
         @target.update_attributes(year: Date.today.year)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'simplecov'
-SimpleCov.start
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
@@ -13,14 +10,14 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 def login_user(*options)
   options = options.extract_options!
-  company = options[:company] || Factory(:company)
+  company = options[:company] || FactoryGirl.create(:company)
   
   user = unless options[:user].nil?
     company.users << options[:user]
     options[:user].current_company = company
     options[:user]
   else
-    user = Factory(:user)
+    user = FactoryGirl.create(:user)
     company.users << user
     user.current_company = company
     user
@@ -35,10 +32,10 @@ def logout_user
   session[:user_id] = nil
 end
 
-def user_with_clients_and_projects(target_user=Factory(:user))
+def user_with_clients_and_projects(target_user=FactoryGirl.create(:user))
   2.times do
-    client = Factory(:client)
-    2.times { Factory(:project, :client => client) }
+    client = FactoryGirl.create(:client)
+    2.times { FactoryGirl.create(:project, :client => client) }
   end
   
   Project.all.each { |p| p.users << target_user }
@@ -47,7 +44,7 @@ def user_with_clients_and_projects(target_user=Factory(:user))
 end
 
 def company_with_users_and_projects
-  Factory(:company).tap do |company|
+  FactoryGirl.create(:company).tap do |company|
     2.times do 
       company.users << user_with_clients_and_projects
     end


### PR DESCRIPTION
- Methods defined in a module extending ActiveSupport::Concern need not
  define an InstanceMethods module. Any method defined in said module
  automatically be available as an instance method to the class
  the module
- We're not using Sendgrid in the development and testing environments
  so only set everything up in config/initializers/mail.rb for
  production
- Removed SimpleCov, which is kind of useless and ugly anyway and
  pollutes the specs with deprecation warnings.
- Fixed FactoryGirl's deprecation warnings
