### PR TITLE
Removed destroy link from project show and index

### DIFF
--- a/app/assets/javascripts/views/projects/project_view.js.coffee
+++ b/app/assets/javascripts/views/projects/project_view.js.coffee
@@ -76,8 +76,7 @@ class views.projects.ProjectView extends views.shared.DateDrivenView
       <header>
         <h2>{{clientName}} : {{project.name}}</h2>
         <div class='actions'>
-          <a href='/projects/{{project.id}}/edit'>Edit Project Details</a> |
-          <a href='/projects/{{project.id}}' data-confirm='Are you sure?' data-method='delete'>Destroy Project</a>
+          <a href='/projects/{{project.id}}/edit'>Edit Project Details</a>
         </div>
       </header>
       <div class='date-pagination'>

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -3,7 +3,9 @@
   
 %section
   %header
-    %h2= @project.name
+    %h2
+      = @project.name
 
   = render 'form'
-
+  %span.actions
+    = link_to "Delete Project", @project, :confirm => t('crud_shared.delete_confirmation'), :method => :delete

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -14,5 +14,3 @@
           %span.project-name= project.name
         .controls
           = link_to t('.edit'), edit_project_path(project)
-          = link_to t('.destroy'), project, :confirm => t('.delete_confirmation'), :method => :delete
-


### PR DESCRIPTION
The project can now only be deleted from the edit page.
