### PR TITLE
Feature [#39517405] Preserve dates on navigation

### DIFF
--- a/app/assets/javascripts/views/date_range_view.js.coffee
+++ b/app/assets/javascripts/views/date_range_view.js.coffee
@@ -27,6 +27,7 @@ class StaffPlan.Views.DateRangeView extends Support.CompositeView
     @dateRangeTemplate = Handlebars.compile(@templates.dates)
 
     @on "date:changed", (message) ->
+      localStorage.setItem "fromDate", message.begin
       @collection = _.range(message.begin, message.begin + message.count * 7 * 86400 * 1000, 7 * 86400 * 1000)
       @render()
 
@@ -36,7 +37,6 @@ class StaffPlan.Views.DateRangeView extends Support.CompositeView
   paginate: (event) ->
     event.preventDefault()
     event.stopPropagation()
-
     @parent.trigger "date:changed",
       action: $(event.target).data('action')
 

--- a/app/assets/javascripts/views/projects/index.js.coffee
+++ b/app/assets/javascripts/views/projects/index.js.coffee
@@ -3,8 +3,9 @@ class window.StaffPlan.Views.Projects.Index extends StaffPlan.View
   
   initialize: ->
     _.extend @, StaffPlan.Mixins.Events.weeks
-    m = moment()
-    @startDate = m.utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
+
+    @startDate = moment(localStorage.getItem("fromDate")) or moment().utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
+
     @collection.bind "remove", () =>
       @render()
 

--- a/app/assets/javascripts/views/projects/show.js.coffee
+++ b/app/assets/javascripts/views/projects/show.js.coffee
@@ -2,8 +2,8 @@ class StaffPlan.Views.Projects.Show extends StaffPlan.View
   className: "list tall"
   initialize: ->
     _.extend @, StaffPlan.Mixins.Events.weeks
-    m = moment()
-    @startDate = m.utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
+
+    @startDate = moment(localStorage.getItem("fromDate")) or moment().utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
 
     key "left, right", (event) =>
       @dateChanged if event.keyIdentifier.toLowerCase() is "left" then "previous" else "next"

--- a/app/assets/javascripts/views/staffplans/index.js.coffee
+++ b/app/assets/javascripts/views/staffplans/index.js.coffee
@@ -32,8 +32,7 @@ class window.StaffPlan.Views.StaffPlans.Index extends StaffPlan.View
     @users = new StaffPlan.Collections.Users @options.users.active()
     @users.reset @users.sortBy (user) -> user.workload()
     
-    m = moment()
-    @startDate = m.utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
+    @startDate = moment(localStorage.getItem("fromDate")) or moment().utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
     
     # When the collection of users changes, we render the view 
     # again to reflect the change in the UI

--- a/app/assets/javascripts/views/staffplans/show.js.coffee
+++ b/app/assets/javascripts/views/staffplans/show.js.coffee
@@ -37,8 +37,8 @@ class window.StaffPlan.Views.StaffPlans.Show extends StaffPlan.View
     
   initialize: ->
     _.extend @, StaffPlan.Mixins.Events.weeks
-    m = moment()
-    @startDate = m.utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
+
+    @startDate = moment(localStorage.getItem("fromDate")) or moment().utc().startOf('day').subtract('days', m.day() - 1).subtract('weeks', 1)
     
     key "left, right", (event) =>
       @dateChanged if event.keyIdentifier.toLowerCase() is "left" then "previous" else "next"


### PR DESCRIPTION
This commit implements the feature.
Upon date pagination, the timestamp of the first day is saved to
localStorage (other mechanisme can be explored as well should
LocalStorage happen to not be a suitable candidate for this feature).
The value is then subsequently used by other views at initialize time.
