### PR TITLE
Bug [#46370195] Restrict reminder to relevant ww's

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -10,7 +10,8 @@ task :send_reminders => :environment do
                 joins(:work_weeks).
                 select("user_id").
                 where("work_weeks.beginning_of_week = ?", @timestamp - 7 * 86400 * 1000).
-                where("actual_hours IS NULL").
+                where("actual_hours IS NULL OR actual_hours = ?", 0).
+                where("estimated_hours IS NOT NULL AND estimated_hours > ?", 0).
                 map { |assignment| User.where(:id => assignment.user_id).first }.
                 uniq
 


### PR DESCRIPTION
Email reminders should only be sent to people for weeks with > 0
estimates and no actuals. This fixes that mistake.
